### PR TITLE
Update example imports for react-pulse-dot

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ npm install --save react-pulse-dot
 ```jsx
 import React, { Component } from 'react'
 
-import PulseDot from ''
+import PulseDot from 'react-pulse-dot'
+import 'react-pulse-dot/dist/index.css'
 
 class Example extends Component {
   render() {


### PR DESCRIPTION
Change '' to 'react-pulse-dot'. Import css, because it doesn't work without importing css.